### PR TITLE
feat: #4-service-monitor-integration

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+           fetch-depth: 0
+           args: detect --redact --report-format=sarif --report-path=results.sarif --exit-code=1
 
       - name: Setup Gitleaks
         uses: gitleaks/gitleaks-action@v2

--- a/k8s/server_service_monitor.yaml
+++ b/k8s/server_service_monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: bookify-server-monitor
+  labels:
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      app: bookify-server
+  endpoints:
+  - port: http
+    path: /metrics
+    interval: 10s


### PR DESCRIPTION
Integrates Prometheus metrics collection by deploying a ServiceMonitor resource that targets the application’s /metrics endpoint. This configuration enables automated scraping of runtime and performance metrics (such as request latency, throughput, and error rates) from the server, ensuring visibility within the kube-prometheus-stack ecosystem.

The collected metrics will be consumed by Prometheus for time-series storage and can be visualized in Grafana dashboards to monitor service health, performance trends, and operational SLIs/SLOs.

This change enhances observability by aligning with Kubernetes-native monitoring standards through the Prometheus Operator’s ServiceMonitor CRD, eliminating the need for manual Prometheus scrape configurations.