### PR TITLE
feat: #9-integrate-kubernetes-nginx-ingress-for-canary-deployment

### DIFF
--- a/k8s/ingress/ingress_pointing_to_canary.yaml
+++ b/k8s/ingress/ingress_pointing_to_canary.yaml
@@ -1,0 +1,26 @@
+
+# Canary Ingress for Bookify application
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bookify-canary
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "20"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api.bookify.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: bookify-canary-service
+            port:
+              number: 5000

--- a/k8s/ingress/ingress_pointing_to_main.yaml
+++ b/k8s/ingress/ingress_pointing_to_main.yaml
@@ -1,0 +1,25 @@
+
+# Ingress for Bookify main application
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: bookify-main
+  namespace: default
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: bookify.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: /
+        backend:
+          service:
+            name: bookify-main-service
+            port:
+              number: 5000


### PR DESCRIPTION
# Integrate Kubernetes NGINX Ingress for Canary Deployment

## Overview
Implement **NGINX Ingress Controller** to enable Canary-style deployments within the Kubernetes environment.  
This integration will allow progressive traffic routing between stable and canary versions of services, enhancing deployment safety and minimizing production risk.

## Objectives
- Configure NGINX Ingress resources to support **weighted routing** between application versions.  
- Define **Ingress annotations** or custom rules for Canary percentage-based rollout.  
- Integrate with **existing CI/CD pipelines** to automate Canary promotion and rollback.  
- Ensure full **observability and traffic monitoring** using Prometheus/Grafana or similar tools.

## Deliverables
- NGINX Ingress Controller manifests and configuration files.  
- Sample deployment manifests for both **stable** and **canary** versions.  
- Documentation for operational workflow, rollout strategy, and rollback procedures.

## Success Criteria
- Canary deployment traffic is split dynamically (e.g., 90/10 → 50/50 → 0/100).  
- Zero downtime during rollout and version transitions.  
- Metrics and logs provide clear visibility into version performance and traffic distribution.
