### PR TITLE
chore: paused gitleaks and trivy dependency (#18) to check dev enviro…

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,7 +52,6 @@ jobs:
 
   trivy_fs_scan:
     runs-on: ubuntu-latest
-    needs: gitleaks-scan
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
…nment (#18)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Security scanning jobs in the CI/CD workflow are now independent and no longer sequentially dependent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->